### PR TITLE
nvml: windows: search for nvml.dll in system32, fix some DLL calls

### DIFF
--- a/nvml/nvml_windows.go
+++ b/nvml/nvml_windows.go
@@ -3,15 +3,15 @@
 package nvml
 
 import (
-	"os"
 	"log"
+	"os"
 	"unsafe"
+
 	"golang.org/x/sys/windows"
 )
 
 const (
 	nvmlSuccess uintptr = 0
-
 )
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 	if err != nil {
 		log.Printf("energy monitoring unavailable")
 	} else {
-		useEnergy=true
+		useEnergy = true
 	}
 	err = getPower.Find()
 	if err != nil {
@@ -42,28 +42,28 @@ func init() {
 			return
 		}
 	}
-	r1,_,err := initNVML.Call()
+	r1, _, err := initNVML.Call()
 	if r1 != nvmlSuccess {
 		log.Printf("failed initializing: %v", err)
 		return
 	}
 	var deviceCount uint64
-	r1,_,err = countDevices.Call(uintptr(unsafe.Pointer(&deviceCount)))
+	r1, _, err = countDevices.Call(uintptr(unsafe.Pointer(&deviceCount)))
 	if r1 != nvmlSuccess {
 		log.Printf("failed counting devices: %v", err)
 		return
 	}
 	log.Printf("found %d devices", deviceCount)
-	for i := uint64(0); i < deviceCount; i ++ {
+	for i := uint64(0); i < deviceCount; i++ {
 		var device uintptr
-		r1,_,err = getDeviceHandleByIndex.Call(uintptr(i),uintptr(unsafe.Pointer(&device)))
+		r1, _, err = getDeviceHandleByIndex.Call(uintptr(i), uintptr(unsafe.Pointer(&device)))
 		if r1 != nvmlSuccess {
 			log.Printf("failed counting devices: %v", err)
 			return
 		}
 		log.Printf("Loaded device %v", device)
 		var arch uint32
-		r1,_,err = getArchitecture.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&arch)))
+		r1, _, err = getArchitecture.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&arch)))
 		if r1 != nvmlSuccess {
 			log.Printf("failed getting device architecture: %v", err)
 			return
@@ -71,7 +71,7 @@ func init() {
 		log.Printf("Device architecture: %v", arch)
 		if useEnergy {
 			var uJ uint64
-			r1,_,err = getEnergy.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&uJ)))
+			r1, _, err = getEnergy.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&uJ)))
 			if r1 != nvmlSuccess {
 				log.Printf("failed reading energy: %v", err)
 				return
@@ -79,7 +79,7 @@ func init() {
 			log.Printf("Read %d uJ", uJ)
 		} else {
 			var mW uint32
-			r1,_, err = getPower.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&mW)))
+			r1, _, err = getPower.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&mW)))
 			if r1 != nvmlSuccess {
 				log.Printf("failed reading power: %v", err)
 			}

--- a/nvml/nvml_windows.go
+++ b/nvml/nvml_windows.go
@@ -3,6 +3,7 @@
 package nvml
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"unsafe"
@@ -14,21 +15,47 @@ const (
 	nvmlSuccess uintptr = 0
 )
 
+func findNVMLDLL() (*windows.LazyDLL, error) {
+	for _, path := range []string{
+		os.ExpandEnv("${ProgramW6432}\\NVIDIA Corporation\\NVSMI\\nvml.dll"),
+		"nvml.dll",
+	} {
+		log.Printf("Trying to load %s", path)
+		tryNVML := windows.NewLazySystemDLL(path)
+		if err := tryNVML.Load(); err == nil {
+			log.Printf("Loaded %s", path)
+			return tryNVML, nil
+		}
+	}
+	return nil, fmt.Errorf("failed to find nvml.dll")
+}
+
 func init() {
-	dllPath := os.ExpandEnv("${ProgramW6432}\\NVIDIA Corporation\\NVSMI\\nvml.dll")
-	log.Printf("dllpath: %v", dllPath)
-	nvml := windows.NewLazyDLL(dllPath)
-	log.Printf("dll: %v", nvml)
+	nvml, err := findNVMLDLL()
+	if err != nil {
+		log.Printf("%v", err)
+		return
+	}
+
 	initNVML := nvml.NewProc("nvmlInit_v2")
 	countDevices := nvml.NewProc("nvmlDeviceGetCount_v2")
 	getDeviceHandleByIndex := nvml.NewProc("nvmlDeviceGetHandleByIndex_v2")
 	getEnergy := nvml.NewProc("nvmlDeviceGetTotalEnergyConsumption")
 	getPower := nvml.NewProc("nvmlDeviceGetPowerUsage")
 	getArchitecture := nvml.NewProc("nvmlDeviceGetArchitecture")
+	getNVMLVersion := nvml.NewProc("nvmlSystemGetNVMLVersion")
+
+	var version [16]byte
+	r1, _, err := getNVMLVersion.Call(uintptr(unsafe.Pointer(&version)), 16)
+	if r1 != nvmlSuccess {
+		log.Printf("failed to get NVML version: %v", err)
+		return
+	}
+	log.Printf("NVML version: %s", string(version[:]))
 
 	useEnergy := false
 
-	err := getEnergy.Find()
+	err = getEnergy.Find()
 	if err != nil {
 		log.Printf("energy monitoring unavailable")
 	} else {
@@ -42,7 +69,7 @@ func init() {
 			return
 		}
 	}
-	r1, _, err := initNVML.Call()
+	r1, _, err = initNVML.Call()
 	if r1 != nvmlSuccess {
 		log.Printf("failed initializing: %v", err)
 		return
@@ -63,7 +90,7 @@ func init() {
 		}
 		log.Printf("Loaded device %v", device)
 		var arch uint32
-		r1, _, err = getArchitecture.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&arch)))
+		r1, _, err = getArchitecture.Call(device, uintptr(unsafe.Pointer(&arch)))
 		if r1 != nvmlSuccess {
 			log.Printf("failed getting device architecture: %v", err)
 			return
@@ -71,7 +98,7 @@ func init() {
 		log.Printf("Device architecture: %v", arch)
 		if useEnergy {
 			var uJ uint64
-			r1, _, err = getEnergy.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&uJ)))
+			r1, _, err = getEnergy.Call(device, uintptr(unsafe.Pointer(&uJ)))
 			if r1 != nvmlSuccess {
 				log.Printf("failed reading energy: %v", err)
 				return
@@ -79,7 +106,7 @@ func init() {
 			log.Printf("Read %d uJ", uJ)
 		} else {
 			var mW uint32
-			r1, _, err = getPower.Call(uintptr(unsafe.Pointer(&device)), uintptr(unsafe.Pointer(&mW)))
+			r1, _, err = getPower.Call(device, uintptr(unsafe.Pointer(&mW)))
 			if r1 != nvmlSuccess {
 				log.Printf("failed reading power: %v", err)
 			}


### PR DESCRIPTION
On my machine :tm: `nvml.dll` is located in system32, so introduce some logic to try to find it there. `windows.NewLazySystemDLL` is useful for this, as it'll assume base names refer to system32, but allow absolute paths otherwise.

Fix the per-device DLL calls by removing a layer of pointer indirection. We receive a pointer to a `nvmlDevice_t` from `nvmlDeviceGetHandleByIndex_v2` and store it inside `device`. The subsequent per-device functions take that pointer directly. Before we were giving it a pointer to the pointer, which isn't valid (it would either throw an exception or a non-sensical error).